### PR TITLE
✨feat: chatgpt stream 연동 / ddl 초안 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// websocket
+//	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1,50 +1,108 @@
 USE wehigher;
 
-CREATE TABLE user(
-
+CREATE TABLE `users`(
+    `id` integer auto_increment,
+    `social_id` varchar(100) not null,
+    `email` varchar(30) not null,
+    `is_graduate` boolean,
+    `is_login` boolean,
+    `is_valid` boolean,
+    `name` varchar(20),
+    `password` varchar(30),
+    `provider` enum('KAKAO', 'NAVER') not null,
+    `refresh_token` varchar(300),
+    `role` enum('USER', 'ADMIN') not null,
+    CONSTRAINT USERS_PK PRIMARY KEY (`id`),
+    CONSTRAINT USERS_CK UNIQUE (`social_id`, `provider`)
 );
 
-CREATE TABLE award(
-
+CREATE TABLE `base_time_entity`(
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP
 );
 
-CREATE TABLE base_time_entity(
-
+CREATE TABLE `award`(
+    `id` integer auto_increment,
+    `date` varchar(20) not null,
+    `institution` varchar(30) not null,
+    `name` varchar(20) not null,
+    `target` varchar(20) not null,
+    `tier` varchar(20) not null,
+    PRIMARY KEY (`id`)
 );
 
-CREATE TABLE career(
-
+CREATE TABLE `career`(
+    `id` integer auto_increment,
+    `grade` tinyint not null,
+    `parent_hope` varchar(20) not null,
+    `student_hope` varchar(20) not null,
+    `reason` varchar(300),
+    `specialty_or_interest` varchar(256),
+    PRIMARY KEY (`id`)
 );
 
-CREATE TABLE common_question(
-
+CREATE TABLE `creative`(
+    `id` integer auto_increment,
+    `activity_time` integer,
+    `area` varchar(20),
+    `grade` tinyint not null,
+    `specialty` varchar(300),
+    PRIMARY KEY (`id`)
 );
 
-CREATE TABLE creative(
-
+CREATE TABLE `educational`(
+    `id` integer auto_increment,
+    `course` varchar(20),
+    `detail_and_specialty` varchar(300),
+    `grade` tinyint,
+    `ranking` tinyint,
+    `semester` varchar(10),
+    `subject` varchar(20),
+    PRIMARY KEY (`id`)
 );
 
-CREATE TABLE educational(
+# CREATE TABLE `interview`(
+#     `id` integer auto_increment
+# );
 
+CREATE TABLE `opinion`(
+    `id` integer auto_increment,
+    `grade` tinyint not null,
+    `content` varchar(300),
+    PRIMARY KEY (`id`)
 );
 
-CREATE TABLE interview(
 
+CREATE TABLE `reading`(
+    `id` integer auto_increment,
+    `grade` tinyint not null,
+    `semester` varchar(10),
+    `subject` varchar(20),
+    `title` varchar(30)
 );
 
-CREATE TABLE opinion(
-
+CREATE TABLE `school_record`(
+    `school_record_id` integer auto_increment,
+    `user_id` integer not null,
+    `career_id` integer not null,
+    `educational_id` integer not null,
+    `opinion_id` integer not null,
+    `reading_id` integer not null,
+    `creative_id` integer not null,
+    `award_id` integer not null,
+    PRIMARY KEY (`school_record_id`),
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+    FOREIGN KEY (`career_id`) REFERENCES `career` (`id`),
+    FOREIGN KEY (`educational_id`) REFERENCES `educational` (`id`),
+    FOREIGN KEY (`opinion_id`) REFERENCES `opinion` (`id`),
+    FOREIGN KEY (`reading_id`) REFERENCES `reading` (`id`),
+    FOREIGN KEY (`creative_id`) REFERENCES `creative` (`id`),
+    FOREIGN KEY (`award_id`) REFERENCES `award` (`id`)
 );
 
-CREATE TABLE qna(
-
+CREATE TABLE `qna`(
+    `id` integer auto_increment,
+    `answer` varchar(200),
+    `question` varchar(200),
+    PRIMARY KEY (`id`)
 );
-
-CREATE TABLE reading(
-
-);
-
-CREATE TABLE school_record(
-
-);
-

--- a/src/main/java/com/dongguk/ossdev/backend/config/ChatGptConfig.java
+++ b/src/main/java/com/dongguk/ossdev/backend/config/ChatGptConfig.java
@@ -1,19 +1,22 @@
 package com.dongguk.ossdev.backend.config;
 
-import lombok.NoArgsConstructor;
+import com.theokanning.openai.service.OpenAiService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 @Configuration
-@NoArgsConstructor
+@Slf4j
 public class ChatGptConfig {
-    public static final String AUTHORIZATION = "Authorization";
-    public static final String BEARER = "Bearer ";
-    public static final String CHAT_MODEL = "gpt-3.5-turbo";
-    public static final Integer MAX_TOKEN = 300;
-    public static final Boolean STREAM = false;
-    public static final String ROLE = "user";
-    public static final Double TEMPERATURE = 0.6;
-    public static final Double TOP_P = 1.0;
-    public static final String MEDIA_TYPE = "application/json; charset=UTF-8";
-    public static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
+    @Value("${chatgpt.api.token}")
+    private String token;
+
+    @Bean
+    public OpenAiService openAIService() {
+        log.info("token : {}을 활용한 OpenAiService 을 생성합니다.", token);
+        return new OpenAiService(token, Duration.ofSeconds(60));
+    }
 }

--- a/src/main/java/com/dongguk/ossdev/backend/controller/ChatGptController.java
+++ b/src/main/java/com/dongguk/ossdev/backend/controller/ChatGptController.java
@@ -1,28 +1,24 @@
 package com.dongguk.ossdev.backend.controller;
 
-import com.dongguk.ossdev.backend.dto.request.QuestionRequestDto;
+import com.dongguk.ossdev.backend.dto.request.ChatGptRequestDto;
 import com.dongguk.ossdev.backend.dto.response.ChatGptResponseDto;
 import com.dongguk.ossdev.backend.service.ChatGptService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Locale;
 
 @RestController
-@RequestMapping("/chat-gpt")
+@RequestMapping("/api/chatgpt")
 @RequiredArgsConstructor
 public class ChatGptController {
     private final ChatGptService chatGptService;
 
-//    @PostMapping("/question")
-//    public ChatGptResponseDto sendQuestion(Locale locale, HttpServletRequest request, HttpServletResponse response,
-//                                           @RequestBody QuestionRequestDto questionRequest) {
-//        ChatGptResponseDto chatGptResponse = chatGptService.askQuestion(questionRequest);
-//        return chatGptResponse;
-//    }
+    @PostMapping("/completion/chat")
+    public ChatGptResponseDto completionChat(final @RequestBody ChatGptRequestDto gptCompletionChatRequest) {
+
+        return chatGptService.completionChat(gptCompletionChatRequest);
+    }
 }

--- a/src/main/java/com/dongguk/ossdev/backend/domain/GPTAnswer.java
+++ b/src/main/java/com/dongguk/ossdev/backend/domain/GPTAnswer.java
@@ -1,0 +1,22 @@
+package com.dongguk.ossdev.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GPTAnswer extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "gpt_answer", length = 1500, nullable = false)
+    private String answer;
+
+    public GPTAnswer(String answer) {
+        this.answer = answer;
+    }
+}

--- a/src/main/java/com/dongguk/ossdev/backend/domain/GPTQuestion.java
+++ b/src/main/java/com/dongguk/ossdev/backend/domain/GPTQuestion.java
@@ -1,0 +1,28 @@
+package com.dongguk.ossdev.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "gpt_question")
+public class GPTQuestion extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "gpt_question", length = 1500, nullable = false)
+    private String question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id")
+    private GPTAnswer answer;
+
+    public GPTQuestion(String question, GPTAnswer answer) {
+        this.question = question;
+        this.answer = answer;
+    }
+}

--- a/src/main/java/com/dongguk/ossdev/backend/dto/request/ChatGptRequestDto.java
+++ b/src/main/java/com/dongguk/ossdev/backend/dto/request/ChatGptRequestDto.java
@@ -1,8 +1,8 @@
 package com.dongguk.ossdev.backend.dto.request;
 
-import com.dongguk.ossdev.backend.domain.ChatGptMessage;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,26 +10,25 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ChatGptRequestDto {
     private String model;
-    private String prompt;
+
+    private String role;
+
+    private String message;
 
     private Integer maxTokens;
-    private Double temperature;
 
-    private Double topP;    // 1.0
-    private Boolean stream;
-    private List<ChatGptMessage> messages;
+    public static ChatCompletionRequest of(ChatGptRequestDto request) {
+        return ChatCompletionRequest.builder()
+                .model(request.getModel())
+                .messages(convertChatMessage(request))
+                .maxTokens(request.getMaxTokens())
+                .build();
+    }
 
-    @Builder
-    public ChatGptRequestDto(String model, String prompt, Integer maxTokens,
-                             Double temperature, Double topP, List<ChatGptMessage> messages, boolean stream) {
-        this.model = model;
-        this.prompt = prompt;
-        this.maxTokens = maxTokens;
-        this.temperature = temperature;
-        this.topP = topP;
-        this.messages = messages;
-        this.stream = stream;
+    private static List<ChatMessage> convertChatMessage(ChatGptRequestDto request) {
+        return List.of(new ChatMessage(request.getRole(), request.getMessage()));
     }
 }

--- a/src/main/java/com/dongguk/ossdev/backend/dto/response/ChatGptResponseDto.java
+++ b/src/main/java/com/dongguk/ossdev/backend/dto/response/ChatGptResponseDto.java
@@ -1,45 +1,83 @@
 package com.dongguk.ossdev.backend.dto.response;
 
-import lombok.Builder;
+import com.theokanning.openai.Usage;
+import com.theokanning.openai.completion.chat.ChatCompletionChoice;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
-import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ChatGptResponseDto {
     private String id;
+
     private String object;
-    private LocalDate created;
+
+    private Long created;
+
     private String model;
-//    private List<Message> messages;
 
-//    @Builder
-//    public ChatGptResponseDto(String id, String object, LocalDate created, String model, List<Message> messages) {
-//        this.id = id;
-//        this.object = object;
-//        this.created = created;
-//        this.model = model;
-//        this.messages = messages;
-//    }
+    private List<Message> messages;
 
-//    @Setter
-//    public static class Usage {
-//        @JsonProperty("prompt_tokens")
-//        private int promptTokens;
-//        @JsonProperty("completion_tokens")
-//        private int completionTokens;
-//        @JsonProperty("total_tokens")
-//        private int totalTokens;
-//    }
-//
-//    @Setter
-//    public static class Choice {
-//        private ChatGptMessage message;
-//        @JsonProperty("finish_reason")
-//        private String finishReason;
-//        private int index;
-//    }
+    private Usage usage;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Message {
+
+        private String role;
+
+        private String message;
+
+        public static Message of(ChatMessage chatMessage) {
+            return new Message(
+                    chatMessage.getRole(),
+                    chatMessage.getContent()
+            );
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Usage {
+
+        private Long promptTokens;
+
+        private Long completionTokens;
+
+        private Long totalTokens;
+
+        public static Usage of(com.theokanning.openai.Usage usage) {
+            return new Usage(
+                    usage.getPromptTokens(),
+                    usage.getCompletionTokens(),
+                    usage.getTotalTokens()
+            );
+        }
+    }
+
+    public static List<ChatGptResponseDto.Message> toResponseListBy(List<ChatCompletionChoice> choices) {
+        return choices.stream()
+                .map(completionChoice -> Message.of(completionChoice.getMessage()))
+                .collect(Collectors.toList());
+    }
+
+    public static ChatGptResponseDto of(ChatCompletionResult result) {
+        return new ChatGptResponseDto(
+                result.getId(),
+                result.getObject(),
+                result.getCreated(),
+                result.getModel(),
+                toResponseListBy(result.getChoices()),
+                Usage.of(result.getUsage())
+        );
+    }
 }

--- a/src/main/java/com/dongguk/ossdev/backend/repository/GPTAnswerRepository.java
+++ b/src/main/java/com/dongguk/ossdev/backend/repository/GPTAnswerRepository.java
@@ -1,0 +1,10 @@
+package com.dongguk.ossdev.backend.repository;
+
+import com.dongguk.ossdev.backend.domain.GPTAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GPTAnswerRepository extends JpaRepository<GPTAnswer, Long> {
+
+}

--- a/src/main/java/com/dongguk/ossdev/backend/repository/GPTQuestionRepository.java
+++ b/src/main/java/com/dongguk/ossdev/backend/repository/GPTQuestionRepository.java
@@ -1,0 +1,9 @@
+package com.dongguk.ossdev.backend.repository;
+
+import com.dongguk.ossdev.backend.domain.GPTQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GPTQuestionRepository extends JpaRepository<GPTQuestion, Long> {
+}

--- a/src/main/java/com/dongguk/ossdev/backend/service/ChatGptService.java
+++ b/src/main/java/com/dongguk/ossdev/backend/service/ChatGptService.java
@@ -1,89 +1,57 @@
 package com.dongguk.ossdev.backend.service;
 
-import com.dongguk.ossdev.backend.config.ChatGptConfig;
-import com.dongguk.ossdev.backend.domain.ChatGptMessage;
+import com.dongguk.ossdev.backend.domain.GPTAnswer;
+import com.dongguk.ossdev.backend.domain.GPTQuestion;
 import com.dongguk.ossdev.backend.dto.request.ChatGptRequestDto;
-import com.dongguk.ossdev.backend.dto.request.QuestionRequestDto;
 import com.dongguk.ossdev.backend.dto.response.ChatGptResponseDto;
+import com.dongguk.ossdev.backend.repository.GPTAnswerRepository;
+import com.dongguk.ossdev.backend.repository.GPTQuestionRepository;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ChatGptService {
-    @Value("${chatgpt.api.token}")
-    private String apiKey;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final OpenAiService openAiService;
+    private final GPTAnswerRepository gptAnswerRepository;
+    private final GPTQuestionRepository gptQuestionRepository;
 
-    public HttpEntity<ChatGptRequestDto> buildHttpEntity(ChatGptRequestDto requestDto) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.parseMediaType(ChatGptConfig.MEDIA_TYPE));
-        headers.add(ChatGptConfig.AUTHORIZATION, ChatGptConfig.BEARER + apiKey);
-        return new HttpEntity<>(requestDto, headers);
+    @Transactional
+    public ChatGptResponseDto completionChat(ChatGptRequestDto gptCompletionChatRequest) {
+        ChatCompletionResult chatCompletion = openAiService.createChatCompletion(
+                ChatGptRequestDto.of(gptCompletionChatRequest));
+
+        ChatGptResponseDto response = ChatGptResponseDto.of(chatCompletion);
+
+        List<String> messages = response.getMessages().stream()
+                .map(ChatGptResponseDto.Message::getMessage)
+                .collect(Collectors.toList());
+
+        GPTAnswer gptAnswer = saveAnswer(messages);
+
+        saveQuestion(gptCompletionChatRequest.getMessage(), gptAnswer);
+
+        return response;
     }
 
-    public ChatGptResponseDto getResponse(HttpEntity<ChatGptRequestDto> chatGptRequestDtoHttpEntity) {
-        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(60000);
-        //답변이 길어질 경우 TimeOut Error가 발생하니 1분정도 설정
-        requestFactory.setReadTimeout(60 * 1000);   //  1min = 60 sec * 1,000ms
-        restTemplate.setRequestFactory(requestFactory);
-
-        ResponseEntity<ChatGptResponseDto> responseEntity = restTemplate.postForEntity(
-                ChatGptConfig.CHAT_URL,
-                chatGptRequestDtoHttpEntity,
-                ChatGptResponseDto.class);
-
-        return responseEntity.getBody();
+    private void saveQuestion(String question, GPTAnswer answer) {
+        GPTQuestion questionEntity = new GPTQuestion(question, answer);
+        gptQuestionRepository.save(questionEntity);
     }
 
-//    public ChatGptResponse askQuestion(QuestionRequest questionRequest){
-//        List<ChatGptMessage> messages = new ArrayList<>();
-//        messages.add(ChatGptMessage.builder()
-//                .role(ChatGptConfig.ROLE)
-//                .content(questionRequest.getQuestion())
-//                .build());
-//        return this.getResponse(
-//                this.buildHttpEntity(
-//                        new ChatGptRequest(
-//                                ChatGptConfig.CHAT_MODEL,
-//                                ChatGptConfig.MAX_TOKEN,
-//                                ChatGptConfig.TEMPERATURE,
-//                                ChatGptConfig.STREAM,
-//                                messages
-//                                //ChatGptConfig.TOP_P
-//                        )
-//                )
-//        );
-//    }
-//
-//    public ChatGptResponseDto askQuestion(QuestionRequestDto requestDto) {
-//        List<ChatGptMessage> messages = new ArrayList<>();
-//        messages.add(ChatGptMessage.builder()
-//                .role(ChatGptConfig.ROLE)
-//                .content(questionRequest.getQuestion())
-//                .build());
-//        return this.getResponse(
-//                this.buildHttpEntity(ChatGptRequestDto.builder()
-//                                .model(ChatGptConfig.CHAT_MODEL)
-//                                .prompt(requestDto.getQuestion())
-//                                .maxTokens(ChatGptConfig.MAX_TOKEN)
-//                                .temperature(ChatGptConfig.TEMPERATURE)
-//                                .topP(ChatGptConfig.TOP_P)
-//                                .stream(ChatGptConfig.STREAM)
-//                                .messages()
-//                                .build()
-//                )
-//        );
-//    }
+    private GPTAnswer saveAnswer(List<String> response) {
+
+        String answer = response.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining());
+
+        return gptAnswerRepository.save(new GPTAnswer(answer));
+    }
 }


### PR DESCRIPTION
chatgpt에 json 형식으로 질문해서 답변 받는 것 까진 되는 거 같고, (인증 필터에서 자꾸 걸러짐, 이거 어떻게 해야됨?)
사용자 요청 있을 때 사용자 생기부의 모든 정보를 chat gpt api 호출해서 질문 넘겨주고 초기 질문 받는 방식으로 수정해야 함.